### PR TITLE
refactor: Use packet loss percentage to decide VM restart

### DIFF
--- a/Check-Network/Check_Network.sh
+++ b/Check-Network/Check_Network.sh
@@ -1,51 +1,57 @@
 #!/bin/sh
 
-set -x
+# set -x  # Enable debug mode for troubleshooting
 
 # Configuration
-TARGET="8.8.8.8"          # Target IP to check connectivity
-VM_NAME="$1"              # VM name to monitor
-TIMEOUT_THRESHOLD=5       # Number of failed checks before restarting
+TARGET="8.8.8.8"          # Target IP for connectivity check
+VM_NAME="$1"              # VM name, passed as the first argument
+PACKET_LOSS_THRESHOLD=40  # Threshold for packet loss percentage to trigger a restart
+SLEEP_INTERVAL=5          # Delay (in seconds) before restarting the VM
 
-
-# Exit if VM_NAME is empty
+# Ensure VM name is provided
 if [ -z "$VM_NAME" ]; then
-    logger -t vm_network_check "Error: VM name is required."
+    echo "Error: VM name is required."
     exit 1
 fi
 
-# Get VM ID based on VM name
-VM_ID=$(qm list | grep -w "$VM_NAME" | awk '{print $1}')
+# Retrieve VM ID based on VM name
+VM_ID=$(qm list | grep -w "$VM_NAME" | awk '{print $1}' | head -n 1)
 
-# Exit if VM is not found
+# Exit if the VM is not found
 if [ -z "$VM_ID" ]; then
-    logger -t vm_network_check "Error: VM '$VM_NAME' not found!"
+    echo "Error: VM '$VM_NAME' not found!"
+    qm list  # Show all VMs for debugging
     exit 1
 fi
 
-logger -t vm_network_check "Checking network for VM '$VM_NAME' (ID: $VM_ID)..."
+echo "Checking network for VM '$VM_NAME' (ID: $VM_ID)..."
 
-# Ping test
-if ! ping -c 5 -W 2 "$TARGET" > /dev/null 2>&1; then
-    logger -t vm_network_check "Network check failed! Counting timeouts..."
-    
-    # Count recent failures from system logs
-    TIMEOUT_COUNT=$(journalctl -t vm_network_check --since "10 minutes ago" | grep -c "Network check failed")
+# Perform a ping test and extract the packet loss percentage
+PING_OUTPUT=$(ping -c 10 -W 1 "$TARGET")
+PACKET_LOSS=$(echo "$PING_OUTPUT" | grep -oP '\d+(?=% packet loss)')
 
-    if [ "$TIMEOUT_COUNT" -ge "$TIMEOUT_THRESHOLD" ]; then
-        logger -t vm_network_check "Timeout exceeded $TIMEOUT_THRESHOLD times! Restarting VM '$VM_NAME' (ID: $VM_ID)..."
-        
-        if qm stop "$VM_ID"; then
-            sleep 5
-            if qm start "$VM_ID"; then
-                logger -t vm_network_check "VM '$VM_NAME' restarted successfully."
-            else
-                logger -t vm_network_check "Error: Failed to start VM '$VM_NAME'."
-            fi
+# Ensure PACKET_LOSS is not empty (to handle unexpected output)
+if [ -z "$PACKET_LOSS" ]; then
+    echo "Error: Unable to determine packet loss from ping output."
+    exit 1
+fi
+
+echo "Packet loss: ${PACKET_LOSS}%"
+
+# Restart VM if packet loss exceeds the threshold
+if [ "$PACKET_LOSS" -ge "$PACKET_LOSS_THRESHOLD" ]; then
+    echo "High packet loss detected ($PACKET_LOSS%)! Restarting VM '$VM_NAME' (ID: $VM_ID)..."
+
+    if qm stop "$VM_ID"; then
+        sleep "$SLEEP_INTERVAL"
+        if qm start "$VM_ID"; then
+            echo "VM '$VM_NAME' restarted successfully."
         else
-            logger -t vm_network_check "Error: Failed to stop VM '$VM_NAME'."
+            echo "Error: Failed to start VM '$VM_NAME'."
         fi
+    else
+        echo "Error: Failed to stop VM '$VM_NAME'."
     fi
 else
-    logger -t vm_network_check "Network is OK."
+    echo "Network is OK. No restart needed."
 fi


### PR DESCRIPTION
- Removed journalctl-based timeout counting
- Simplified script by removing logger, using echo for direct output